### PR TITLE
Fixed parent module and workspace redirection

### DIFF
--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -93,9 +93,14 @@ class ArticleController extends BaseController
     public function updateArticleStatus(Request $request, $article_id)
     {
         try {
-            $workspace = $this->articleRepository->updateArticleStatus($request->all(), $article_id);
+            $article = $this->articleRepository->updateArticleStatus($request->all(), $article_id);
+            
+            if($article->is_parent_archived == 1){
+                return $this->sendSuccessResponse($article , config('response_messages.restore_module_first'), config('statuscodes.OK'));
+                
+            }
 
-            return $this->sendSuccessResponse($workspace, config('response_messages.article_status_updated'), config('statuscodes.OK'));
+            return $this->sendSuccessResponse($article, config('response_messages.article_status_updated'), config('statuscodes.OK'));
         } catch (\Exception $e) {
             return $this->sendErrorResponse($e->getMessage(), config('response_messages.failed_to_update_article_status'), config('statuscodes.BAD_REQUEST'));
         }

--- a/app/Http/Controllers/ModuleController.php
+++ b/app/Http/Controllers/ModuleController.php
@@ -134,6 +134,11 @@ class ModuleController extends BaseController
         try {
             $module = $this->moduleRepository->updateModuleStatus($request->all(), $module_id);
 
+            if($module->is_parent_archived == 1){
+                return $this->sendSuccessResponse($module , config('response_messages.restore_workspace_first'), config('statuscodes.OK'));
+                
+            }
+
             return $this->sendSuccessResponse($module, config('response_messages.module_status_updated'), config('statuscodes.OK'));
         } catch (\Exception $e) {
             return $this->sendErrorResponse($e->getMessage(), config('response_messages.failed_to_update_module_status'), config('statuscodes.BAD_REQUEST'));

--- a/app/Http/Requests/StoreArticleRequest.php
+++ b/app/Http/Requests/StoreArticleRequest.php
@@ -25,7 +25,7 @@ class StoreArticleRequest extends FormRequest
     {
         return [
             'title' => ['required', 'string', 'max:255'],
-            'content' => ['required', 'string'],
+            'content' => ['required_if:status,!2'],
             'module_id' => ['required', 'integer', 'exists:modules,id'],
         ];
     }

--- a/app/Http/Requests/UpdateArticleRequest.php
+++ b/app/Http/Requests/UpdateArticleRequest.php
@@ -25,7 +25,7 @@ class UpdateArticleRequest extends FormRequest
     {
         return [
             'title' => ['required', 'string', 'max:255'],
-            'content' => ['required', 'string'],
+            'content' => ['required_if:status,!2'],
             'article_id' => ['required', 'integer', 'exists:articles,id'],
             'status' => ['required', 'integer', 'in:1,2'],
         ];

--- a/app/Repositories/ArticleRepository.php
+++ b/app/Repositories/ArticleRepository.php
@@ -153,14 +153,15 @@ class ArticleRepository
             
             if($data['status'] == config('constants.ARTICLE_ACTIVE_STATUS')) {
                 if($article->module->workspace->status == config('constants.WORKSPACE_ARCHIVED_STATUS') || $article->module->status == config('constants.MODULE_ARCHIVED_STATUS')) {
-                    throw new \Exception(config('response_messages.restore_module_first'));
+                    $article->is_parent_archived = config('constants.PARENT_ARCHIVED');
+                    return $article;
                 }
             }
 
             $article->status = $data['status'];
             $article->updated_by = Auth::id();
             $article->save();
-
+            $article->is_parent_archived = config('constants.PARENT_NOT_ARCHIVED');
             return $article;
         } catch (\Exception $e) {
             throw new \Exception($e->getMessage());

--- a/app/Repositories/ModuleRepository.php
+++ b/app/Repositories/ModuleRepository.php
@@ -206,7 +206,8 @@ class ModuleRepository
 
             if($data['status'] == config('constants.MODULE_ACTIVE_STATUS')){
                 if($module->workspace && $module->workspace->status == config('constants.WORKSPACE_ARCHIVED_STATUS')){
-                    throw new \Exception(config('response_messages.restore_workspace_first'));
+                    $module->is_parent_archived = config('constants.PARENT_ARCHIVED');
+                    return $module;
                 }
             }
 
@@ -222,6 +223,7 @@ class ModuleRepository
                 
             }
             DB::commit();
+            $module->is_parent_archived = config('constants.PARENT_NOT_ARCHIVED');
             return $module;
         } catch (\Exception $e) {
             DB::rollBack();

--- a/config/constants.php
+++ b/config/constants.php
@@ -11,4 +11,7 @@
         'ARTICLE_ACTIVE_STATUS' => 1,
         'ARTICLE_ARCHIVED_STATUS' => 0,
         'ARTICLE_DRAFT_STATUS' => 2,
+
+        'PARENT_ARCHIVED' => 1,
+        'PARENT_NOT_ARCHIVED' => 0,
     ];

--- a/database/migrations/2025_04_28_070037_make_articles_content_nullable.php
+++ b/database/migrations/2025_04_28_070037_make_articles_content_nullable.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('articles', function (Blueprint $table) {
+            $table->longText('content')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('articles', function (Blueprint $table) {
+            $table->longText('content')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/views/adminland/archivedarticle.blade.php
+++ b/resources/views/adminland/archivedarticle.blade.php
@@ -178,22 +178,34 @@
 		})
 		.then(response => response.json())
 		.then(data => { 
+			
 			if (data.success) {
-				toastify.success(data.message);
-				
 				const articleData = data.data;
+				const is_parent_archived = articleData.is_parent_archived;
 				const workspace_slug = articleData.module.workspace.slug;
 				const module_slug = articleData.module.slug;
 				const article_slug = articleData.slug;
-				window.location.href = "{{ route('articles.articleDetails', ['workspace_slug' => ':workspace_slug', 'module_slug' => ':module_slug', 'article_slug' => ':article_slug']) }}"
+				
+				if(is_parent_archived == 1){
+					
+					const url = "{{ route('modules.getArchivedModule', ['workspace_slug' => ':workspace_slug', 'module_slug' => ':module_slug']) }}"
+						.replace(':workspace_slug', workspace_slug)
+						.replace(':module_slug', module_slug);
+					
+
+					const link = `<a href="`+url+`" style="color: {{$color}}; text-decoration: underline;">parent module</a>`;
+					const htmlMessage = data.message.replace(":parent_module", link);
+					toastify.errorWithRedirection(htmlMessage);
+				} else {
+					toastify.success(data.message);
+					window.location.href = "{{ route('articles.articleDetails', ['workspace_slug' => ':workspace_slug', 'module_slug' => ':module_slug', 'article_slug' => ':article_slug']) }}"
 						.replace(':workspace_slug', workspace_slug)
 						.replace(':module_slug', module_slug)
 						.replace(':article_slug', article_slug);
+				}
+				
 			} else {
-				//toastify.error(data.message);
-				const link = `<a href="{{ route('adminland.archivedmodules') }}" style="color: {{$color}}; text-decoration: underline;">parent module</a>`;
-				const htmlMessage = data.message.replace(":parent_module", link);
-				toastify.errorWithRedirection(htmlMessage);
+				toastify.error(data.message);
 			}   
 		})
 		.catch(error => {

--- a/resources/views/adminland/archivedmodule.blade.php
+++ b/resources/views/adminland/archivedmodule.blade.php
@@ -162,21 +162,30 @@
 		.then(response => response.json())
 		.then(data => {
 			if (data.success) {
-				toastify.success(data.message);
+				
 				const moduleData = data.data;
 				const workspace_slug = moduleData.workspace.slug;
 				const module_slug = moduleData.slug;
+				const is_parent_archived = moduleData.is_parent_archived;
+				if(is_parent_archived  == 1){
+					const url = "{{ route('workspaces.getArchivedWorkspace', ['workspace_slug' => ':workspace_slug']) }}"
+						.replace(':workspace_slug', workspace_slug);
+					
 
-				setTimeout(() => { 
-					window.location.href = "{{ route('articles.articles', ['workspace_slug' => ':workspace_slug', 'module_slug' => ':module_slug']) }}"
-						.replace(':workspace_slug', workspace_slug)
-						.replace(':module_slug', module_slug);
-				}, 1000);
+					const link = `<a href="`+url+`" style="color: {{$color}}; text-decoration: underline;">parent workspace</a>`;
+					const htmlMessage = data.message.replace(":parent_workspace", link);
+					toastify.errorWithRedirection(htmlMessage);
+				} else {
+					toastify.success(data.message);
+					setTimeout(() => { 
+						window.location.href = "{{ route('articles.articles', ['workspace_slug' => ':workspace_slug', 'module_slug' => ':module_slug']) }}"
+							.replace(':workspace_slug', workspace_slug)
+							.replace(':module_slug', module_slug);
+					}, 1000);
+				}
+				
 			} else {
-				//toastify.error(data.message);
-				const link = `<a href="{{ route('adminland.archivedworkspaces') }}" style="color: {{$color}}; text-decoration: underline;">parent workspace</a>`;
-				const htmlMessage = data.message.replace(":parent_workspace", link);
-				toastify.errorWithRedirection(htmlMessage);
+				toastify.error(data.message);
 			}
 		})
 		.catch(error => {

--- a/resources/views/articles/addarticle.blade.php
+++ b/resources/views/articles/addarticle.blade.php
@@ -132,7 +132,7 @@
 
             // Check if editor is empty (excluding HTML tags)
             const quillText = window.quill.getText().trim();
-            if (quillText === "") {
+            if (quillText === "" && status != 2) {
                 toastify.error("Please add some content.");
                 return;
             }
@@ -142,7 +142,10 @@
                 return;
             }
 
-            const quillContent = quill.root.innerHTML; // Get Quill editor content
+            let quillContent = quill.root.innerHTML; // Get Quill editor content
+            if(quillContent === "<p><br></p>") {
+                quillContent = ""; // Set to null if empty
+            }
             document.getElementById("quill-content").value = quillContent; // Set hidden input value
 
             const moduleId = document.getElementById("module-id").value;

--- a/resources/views/articles/archivedarticle.blade.php
+++ b/resources/views/articles/archivedarticle.blade.php
@@ -161,21 +161,31 @@
             .then(response => response.json())
             .then(data => { 
                 if (data.success) {
-                    toastify.success(data.message);
-                    
                     const articleData = data.data;
+                    const is_parent_archived = articleData.is_parent_archived;
                     const workspace_slug = articleData.module.workspace.slug;
                     const module_slug = articleData.module.slug;
                     const article_slug = articleData.slug;
-                    window.location.href = "{{ route('articles.articleDetails', ['workspace_slug' => ':workspace_slug', 'module_slug' => ':module_slug', 'article_slug' => ':article_slug']) }}"
+                    
+                    if(is_parent_archived == 1){
+                        
+                        const url = "{{ route('modules.getArchivedModule', ['workspace_slug' => ':workspace_slug', 'module_slug' => ':module_slug']) }}"
+                            .replace(':workspace_slug', workspace_slug)
+                            .replace(':module_slug', module_slug);
+                        
+
+                        const link = `<a href="`+url+`" style="color: {{$color}}; text-decoration: underline;">parent module</a>`;
+                        const htmlMessage = data.message.replace(":parent_module", link);
+                        toastify.errorWithRedirection(htmlMessage);
+                    } else {
+                        toastify.success(data.message);
+                        window.location.href = "{{ route('articles.articleDetails', ['workspace_slug' => ':workspace_slug', 'module_slug' => ':module_slug', 'article_slug' => ':article_slug']) }}"
                             .replace(':workspace_slug', workspace_slug)
                             .replace(':module_slug', module_slug)
                             .replace(':article_slug', article_slug);
+                    }
                 } else {
-                    //toastify.error(data.message);
-                    const link = `<a href="{{ route('adminland.archivedmodules') }}" style="color: {{$color}}; text-decoration: underline;">parent module</a>`;
-                    let htmlMessage = data.message.replace(":parent_module", link);
-                    toastify.errorWithRedirection(htmlMessage);
+                    toastify.error(data.message);
                 }   
             })
             .catch(error => {

--- a/resources/views/articles/articledetails.blade.php
+++ b/resources/views/articles/articledetails.blade.php
@@ -246,7 +246,7 @@
 
             // Check if editor is empty (excluding HTML tags)
             const quillText = window.quill.getText().trim();
-            if (quillText === "") {
+            if (quillText === "" && status != 2) {
                 toastify.error("Please add some content.");
                 return;
             }
@@ -256,7 +256,10 @@
                 return;
             }
 
-            const quillContent = quill.root.innerHTML; // Get Quill editor content
+            let quillContent = quill.root.innerHTML; // Get Quill editor content
+            if(quillContent === "<p><br></p>") {
+                quillContent = ""; // Set to null if empty
+            }
 
             // Prepare form data
             const formData = new FormData();

--- a/resources/views/modules/archivedmodule.blade.php
+++ b/resources/views/modules/archivedmodule.blade.php
@@ -119,7 +119,7 @@
                         @foreach($module->articles as $article)
                             <div class="{{ $loop->last ? '' : 'border-b pb-5 ' }} border-gray-200 dark:border-gray-700">
                                 <a
-                                    href="#"
+                                    href="{{route('articles.getArchivedArticle', ['workspace_slug' => $module->workspace['slug'], 'module_slug' => $module->slug, 'article_slug' => $article['slug']])}}"
                                     class="text-lg font-semibold text-gray-900 dark:text-white hover:underline line-clamp-2">
                                     {{$article->title}}
                                 </a>
@@ -224,21 +224,28 @@
 		.then(response => response.json())
 		.then(data => {
 			if (data.success) {
-                toastify.success(data.message);
-				const moduleData = data.data;
+                const moduleData = data.data;
 				const workspace_slug = moduleData.workspace.slug;
 				const module_slug = moduleData.slug;
+				const is_parent_archived = moduleData.is_parent_archived;
+				if(is_parent_archived  == 1){
+					const url = "{{ route('workspaces.getArchivedWorkspace', ['workspace_slug' => ':workspace_slug']) }}"
+						.replace(':workspace_slug', workspace_slug);
+					
 
-				setTimeout(() => { 
-					window.location.href = "{{ route('articles.articles', ['workspace_slug' => ':workspace_slug', 'module_slug' => ':module_slug']) }}"
-						.replace(':workspace_slug', workspace_slug)
-						.replace(':module_slug', module_slug);
-				}, 1000);
+					const link = `<a href="`+url+`" style="color: {{$color}}; text-decoration: underline;">parent workspace</a>`;
+					const htmlMessage = data.message.replace(":parent_workspace", link);
+					toastify.errorWithRedirection(htmlMessage);
+				} else {
+					toastify.success(data.message);
+					setTimeout(() => { 
+						window.location.href = "{{ route('articles.articles', ['workspace_slug' => ':workspace_slug', 'module_slug' => ':module_slug']) }}"
+							.replace(':workspace_slug', workspace_slug)
+							.replace(':module_slug', module_slug);
+					}, 1000);
+				}
 			} else {
-				//toastify.error(data.message);
-				const link = `<a href="{{ route('adminland.archivedworkspaces') }}" style="color: {{$color}}; text-decoration: underline;">parent workspace</a>`;
-				let htmlMessage = data.message.replace(":parent_workspace", link);
-				toastify.errorWithRedirection(htmlMessage);
+				toastify.error(data.message);
 			}
 		})
 		.catch(error => {


### PR DESCRIPTION
Worked on QCKKB-46 to resolve parent module and parent workspace redirection from archived module or archived articles page. Also made the articles.content field nullable if is it saved as draft.